### PR TITLE
Fix long break interval condition

### DIFF
--- a/lib/features/pomodoro/presentation/providers/home_providers.dart
+++ b/lib/features/pomodoro/presentation/providers/home_providers.dart
@@ -123,8 +123,8 @@ class HomeStateNotifyProvider extends StateNotifier<HomeState?> {
       return; // No state initialized
     }
 
-    if (state!.pomodoroCount == _defaultLongBreakPomodoroCount) {
-      // If 4 pomodoros completed, start long break
+    if (state!.pomodoroCount % _defaultLongBreakPomodoroCount == 0) {
+      // Every 4 completed pomodoros triggers a long break
       state = state!.copyWith(
         state: PomodoroState.longBreak,
         releaseTime: _defaultLongBreakDuration,


### PR DESCRIPTION
## Summary
- fix break logic so a long break triggers every 4 pomodoros

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa39dd070832493267bcb66987623